### PR TITLE
Refactor: Upload an image in advance

### DIFF
--- a/train.py
+++ b/train.py
@@ -38,16 +38,9 @@ def parse_args():
     parser.add_argument("--device", default="cuda" if cuda.is_available() else "cpu")
     parser.add_argument("--num_workers", type=int, default=8)
 
-    parser.add_argument("--image_size", type=int, default=2048)
-    parser.add_argument("--input_size", type=int, default=1024)
     parser.add_argument("--batch_size", type=int, default=8)
     parser.add_argument("--learning_rate", type=float, default=1e-3)
     parser.add_argument("--max_epoch", type=int, default=150)
-    parser.add_argument(
-        "--ignore_tags",
-        type=list,
-        default=["masked", "excluded-region", "maintable", "stamp"],
-    )
 
     parser.add_argument("--exp_name", type=str, default="[tag]ExpName_V1")
     parser.add_argument("--seed", type=int, default=3)
@@ -56,9 +49,6 @@ def parse_args():
     parser.add_argument("--patience", type=int, default=10)
 
     args = parser.parse_args()
-
-    if args.input_size % 32 != 0:
-        raise ValueError("`input_size` must be a multiple of 32")
 
     return args
 
@@ -121,13 +111,10 @@ def do_training(
     data_dir,
     model_dir,
     device,
-    image_size,
-    input_size,
     num_workers,
     batch_size,
     learning_rate,
     max_epoch,
-    ignore_tags,
     exp_name,
     seed,
     n_save,
@@ -153,9 +140,6 @@ def do_training(
         data_dir,
         split="train",
         num=split_num,
-        image_size=image_size,
-        crop_size=input_size,
-        ignore_tags=ignore_tags,
     )
     train_dataset = EASTDataset(train_dataset)
     train_num_batches = math.ceil(len(train_dataset) / batch_size)
@@ -168,9 +152,6 @@ def do_training(
         data_dir,
         split="val",
         num=split_num,
-        image_size=image_size,
-        crop_size=input_size,
-        ignore_tags=ignore_tags,
     )
     val_dataset = EASTDataset(val_dataset)
     val_num_batches = math.ceil(len(val_dataset) / batch_size)

--- a/utils/preprocessing.ipynb
+++ b/utils/preprocessing.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import os.path as osp\n",
+    "import json\n",
+    "from tqdm import tqdm\n",
+    "import pickle\n",
+    "\n",
+    "import numpy as np\n",
+    "import cv2\n",
+    "\n",
+    "os.chdir('/opt/ml/input/local')\n",
+    "from dataset import filter_vertices, resize_img, adjust_height, rotate_img, crop_img"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def preprocessing(\n",
+    "        root_dir,\n",
+    "        split=\"train\",\n",
+    "        num=0,\n",
+    "        image_size=2048,\n",
+    "        crop_size=1024,\n",
+    "        ignore_tags=[\"masked\", \"excluded-region\", \"maintable\", \"stamp\"],\n",
+    "        ignore_under_threshold=10,\n",
+    "        drop_under_threshold=1,\n",
+    "    ):\n",
+    "    \n",
+    "        if crop_size % 32 != 0:\n",
+    "            raise ValueError(\"`input_size` must be a multiple of 32\")\n",
+    "        \n",
+    "        if num == 0:\n",
+    "            json_dir = osp.join(root_dir, \"ufo/{}.json\".format(split))\n",
+    "            pkl_dir = osp.join(root_dir, \"ufo/{}.pickle\".format(split))\n",
+    "        else:\n",
+    "            json_dir = osp.join(root_dir, \"ufo/{}.json\".format(split + str(num)))\n",
+    "            pkl_dir = osp.join(root_dir, \"ufo/{}.pickle\".format(split + str(num)))\n",
+    "\n",
+    "        with open(json_dir, \"r\") as f:\n",
+    "            anno = json.load(f)\n",
+    "\n",
+    "        image_fnames = sorted(anno[\"images\"].keys())\n",
+    "        if split == \"val\":\n",
+    "            split = \"train\"\n",
+    "        image_dir = osp.join(root_dir, \"img\", split)\n",
+    "        \n",
+    "        total = dict(images = [],\n",
+    "                     vertices = [],\n",
+    "                     labels = [])\n",
+    "        for idx in tqdm(range(len(image_fnames))):\n",
+    "            image_fname = image_fnames[idx]\n",
+    "            image_fpath = osp.join(image_dir, image_fname)\n",
+    "\n",
+    "            ########################################################################\n",
+    "            vertices, labels = [], []\n",
+    "            for word_info in anno[\"images\"][image_fname][\"words\"].values():\n",
+    "                word_tags = word_info[\"tags\"]\n",
+    "                ignore_sample = any(\n",
+    "                    elem for elem in word_tags if elem in ignore_tags\n",
+    "                )\n",
+    "                num_pts = np.array(word_info[\"points\"]).shape[0]\n",
+    "\n",
+    "                if ignore_sample or num_pts > 4:\n",
+    "                    continue\n",
+    "\n",
+    "                vertices.append(np.array(word_info[\"points\"]).flatten())\n",
+    "                labels.append(int(not word_info[\"illegibility\"]))\n",
+    "            vertices, labels = np.array(vertices, dtype=np.float32), np.array(\n",
+    "                labels, dtype=np.int64\n",
+    "            )\n",
+    "            ########################################################################\n",
+    "\n",
+    "            vertices, labels = filter_vertices(\n",
+    "                vertices,\n",
+    "                labels,\n",
+    "                ignore_under=ignore_under_threshold,\n",
+    "                drop_under=drop_under_threshold,\n",
+    "            )\n",
+    "            image = cv2.imread(image_fpath)\n",
+    "            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)\n",
+    "\n",
+    "            #######################################################################\n",
+    "            image, vertices = resize_img(image, vertices, image_size)\n",
+    "            image, vertices = adjust_height(image, vertices)\n",
+    "            image, vertices = rotate_img(image, vertices)\n",
+    "            image, vertices = crop_img(image, vertices, labels, crop_size)\n",
+    "            #######################################################################\n",
+    "\n",
+    "            total[\"images\"].append(image)\n",
+    "            total[\"vertices\"].append(vertices)\n",
+    "            total[\"labels\"].append(labels)\n",
+    "        \n",
+    "        print(f\"Save path >> {pkl_dir}\")\n",
+    "        with open(pkl_dir,'wb') as fw:\n",
+    "            pickle.dump(total, fw)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- 수정 가능한 부분\n",
+    "    - root_dir\n",
+    "    - split : \"train\" or \"val\"\n",
+    "    - num : json 파일에 붙은 num을 그대로 사용"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 61/61 [04:05<00:00,  4.02s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Save path >> /opt/ml/input/data/medical/ufo/val2.pickle\n"
+     ]
+    }
+   ],
+   "source": [
+    "preprocessing(\n",
+    "        root_dir = '/opt/ml/input/data/medical',\n",
+    "        split=\"val\",\n",
+    "        num=2,\n",
+    "        image_size=2048,\n",
+    "        crop_size=1024,\n",
+    "        ignore_tags=[\"masked\", \"excluded-region\", \"maintable\", \"stamp\"],\n",
+    "        ignore_under_threshold=10,\n",
+    "        drop_under_threshold=1,\n",
+    "    )"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- 저장 되었는지 확인"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('/opt/ml/input/data/medical/ufo/train3.pickle', 'rb') as fr:\n",
+    "    total = pickle.load(fr)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ocr",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Github issue #2

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## 작업사항
- 이미지를 미리 pickle 파일로 만들어서 이전에 실험마다 걸리던 약 20분의 시간을 없앨 수 있습니다.
- 이미지 로드 시간을 줄인 것이므로 학습 시간에는 이전과 변화된 것은 없습니다.
- 이미지를 미리 로드해서 pickle 파일로 만들었을 때 `train2.json`, `val2.json`을 기준으로 726.97MB, 184.80MB정도의 저장 용량을 차지하고 있어 직접 파일을 만들어서 사용하시는 편이  좋아 보입니다.
- pickle  파일의 경우 `train2.json`, `val2.json`이면 `train2.pickle`, `val2.pickle`로 저장됩니다.
- pickle파일로 만드는 파일은 `utils/preprocessing.ipynb`에 작성해 두었습니다.
- 이와 더불어 `train.py`, `dataset.py`도 조금 변경되었습니다.
  - 큰 변경점은 없고 몇 가지 기능들이 `utils/preprocessing.ipynb`에서 진행됨에 따라 사용되지 않는 변수들을 삭제했습니다.
  - 나머지는 그냥 사용하시던 대로 사용하시면 되도록 작성해두었습니다.
    - Ex) `split_num=2`이면 `train2.pickle`, `val2.pickle`을 불러옵니다.

PR #12 